### PR TITLE
feat(build): 新增 sitemap.xml 自動生成

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,11 @@ Build steps: checkout → setup Node (reads `.nvmrc`) → `npm ci` → `npm run 
 
 The `master` branch is legacy from the previous `gh-pages` package flow and is no longer used for serving content. `.travis.yml` has been removed; Travis CI is no longer part of the pipeline.
 
+## Git Workflow
+
+- **`develop` 分支受保護**：不可直接 push commit 到 `develop`，所有功能修改必須先建立新分支（例如 `feature/xxx`、`fix/xxx`），再透過 Pull Request 合併
+- 分支命名慣例：`feature/<功能名稱>`、`fix/<問題描述>`、`refactor/<重構範圍>`
+
 ## Important Notes
 
 - **SSR is disabled**: This is a purely static site for GitHub Pages

--- a/scripts/generateFeeds.mjs
+++ b/scripts/generateFeeds.mjs
@@ -1,5 +1,5 @@
-// 此腳本負責生成 RSS/Atom feeds 和搜尋索引
-// 會在 Nuxt build 完成後由 nitro:build:public-assets hook 呼叫
+// 此腳本負責生成 RSS/Atom feeds、搜尋索引和 sitemap
+// 會在 Nuxt build 完成後由 close hook 呼叫
 import path from 'path';
 import fs from 'fs';
 import { Feed } from 'feed';
@@ -7,6 +7,7 @@ import { createClient } from 'contentful';
 import map from 'lodash/map.js';
 import { fileURLToPath } from 'url';
 import config from '../config/index.mjs';
+import { generateSitemap } from './generateSitemap.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -145,8 +146,9 @@ export async function generateSearchIndex(outputDir, articles = null) {
   console.log(`✓ 搜尋索引已產生至 dist/：search-index.json (${searchIndex.length} 篇文章)`);
 }
 
-// 主函數：同時生成 feeds 和搜尋索引
+// 主函數：同時生成 feeds、搜尋索引和 sitemap
 export async function generateAllFeeds(outputDir) {
   const articles = await generateFeeds(outputDir);
   await generateSearchIndex(outputDir, articles);
+  generateSitemap(outputDir, articles);
 }

--- a/scripts/generateSitemap.mjs
+++ b/scripts/generateSitemap.mjs
@@ -1,0 +1,96 @@
+// 此腳本負責生成 sitemap.xml
+// 會在 Nuxt build 完成後由 close hook 呼叫
+import path from 'path';
+import fs from 'fs';
+import config from '../config/index.mjs';
+
+const DOMAIN = config.domain;
+
+/**
+ * 根據路徑推算優先權：首頁最高，文章次之，其餘較低
+ */
+function getPriority(route) {
+  if (route === '/') return '1.0';
+  if (route.startsWith('/article/')) return '0.8';
+  if (route.startsWith('/tag/')) return '0.6';
+  if (route === '/archives') return '0.5';
+  if (route === '/about') return '0.5';
+  if (route.startsWith('/page/')) return '0.4';
+  return '0.5';
+}
+
+function getChangeFreq(route) {
+  if (route === '/') return 'daily';
+  if (route.startsWith('/article/')) return 'monthly';
+  if (route.startsWith('/tag/')) return 'weekly';
+  if (route === '/archives') return 'weekly';
+  return 'monthly';
+}
+
+/**
+ * 產生 sitemap.xml 並寫入指定目錄
+ * @param {string} outputDir - 輸出目錄（通常是 dist/）
+ * @param {Array} articles - 從 Contentful 取得的文章陣列，用於取得 lastmod
+ */
+export function generateSitemap(outputDir, articles = []) {
+  console.log('開始產生 sitemap.xml...');
+
+  // 建立文章 id → createDate 的對照表，供 lastmod 使用
+  const articleDateMap = new Map();
+  articles.forEach((article) => {
+    if (article.id && article.createDate) {
+      articleDateMap.set(article.id, article.createDate);
+    }
+  });
+
+  // 靜態頁面（不在 generate-routes.json 中但需要收錄）
+  const staticRoutes = ['/', '/archives', '/about'];
+
+  // 從 generate-routes.json 讀取動態路由
+  let dynamicRoutes = [];
+  const routesPath = path.resolve(outputDir, '../scripts/generate-routes.json');
+  try {
+    if (fs.existsSync(routesPath)) {
+      dynamicRoutes = JSON.parse(fs.readFileSync(routesPath, 'utf-8'));
+    }
+  } catch (err) {
+    console.warn('無法載入 generate-routes.json，僅產生靜態頁面的 sitemap：', err.message);
+  }
+
+  // 合併所有路由並去重
+  const allRoutes = [...new Set([...staticRoutes, ...dynamicRoutes])];
+
+  const today = new Date().toISOString().split('T')[0];
+
+  const urls = allRoutes.map((route) => {
+    // 從文章路徑取出 id，查對照表取得 lastmod
+    let lastmod = today;
+    const articleMatch = route.match(/^\/article\/(.+)$/);
+    if (articleMatch) {
+      const articleDate = articleDateMap.get(articleMatch[1]);
+      if (articleDate) {
+        lastmod = new Date(articleDate).toISOString().split('T')[0];
+      }
+    }
+
+    return `  <url>
+    <loc>${DOMAIN}${route}</loc>
+    <lastmod>${lastmod}</lastmod>
+    <changefreq>${getChangeFreq(route)}</changefreq>
+    <priority>${getPriority(route)}</priority>
+  </url>`;
+  });
+
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join('\n')}
+</urlset>
+`;
+
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  fs.writeFileSync(path.join(outputDir, 'sitemap.xml'), sitemap);
+  console.log(`✓ sitemap.xml 已產生至 dist/（${allRoutes.length} 個網址）`);
+}


### PR DESCRIPTION
## Summary

- 新增 `scripts/generateSitemap.mjs`，在 build 完成後自動生成 `sitemap.xml`
- 整合至 `generateAllFeeds()` 流程，與 feeds、搜尋索引共用同一次 Contentful API 資料，不額外發送請求
- 涵蓋靜態頁面（`/`、`/archives`、`/about`）與 `generate-routes.json` 中的所有動態路由
- 文章頁面使用 `createDate` 作為 `lastmod`，依路徑類型設定 `priority` 與 `changefreq`
- 補充 CLAUDE.md 的 Git Workflow 段落，記錄分支保護規則與命名慣例

## Background

`robots.txt` 已宣告 `Sitemap: https://monkeybinbin.github.io/sitemap.xml`，但先前沒有任何機制產生該檔案，搜尋引擎請求時會得到 404。